### PR TITLE
Make sure tempdir is always deleted

### DIFF
--- a/dpp_runner/lib.py
+++ b/dpp_runner/lib.py
@@ -61,9 +61,11 @@ class DppRunner:
                 ]
                 if verbosity > 0:
                     logging.info('Results %r', self.running[uid])
-                del self.running[uid]['dir']
         except Exception as e:
             logging.exception('Failed to run pipelines')
+        finally:
+            self.running[uid]['dir'].cleanup()
+            del self.running[uid]['dir']
 
 
     def start(self, kind, data, verbosity=0, status_cb=None):


### PR DESCRIPTION
## Analysis:

Deleting the temp dir object implicitly deletes the temporary directory with all the pipeline run artifacts.
However, an exception while running the pipelines would leave that object hanging there, undeleted.

## Solution:

Now we're making sure that the folder is deleted (in the finally clause) as well as explicitly calling the `cleanup()` method.

/cc @zelima